### PR TITLE
Remove accessPolicy to flaky-service

### DIFF
--- a/.nais/app.yaml
+++ b/.nais/app.yaml
@@ -77,8 +77,6 @@ spec:
       memory: "256Mi"
   accessPolicy:
     outbound:
-      rules:
-        - application: flaky-service
       external:
         - host: login.microsoftonline.com
   filesFrom:


### PR DESCRIPTION
The application doesn't exist and seems like a flaky name *hihi*, so remove it to silence warning in Console